### PR TITLE
Filter placeholder memory fragments

### DIFF
--- a/python/extensions/monologue_end/_50_memorize_fragments.py
+++ b/python/extensions/monologue_end/_50_memorize_fragments.py
@@ -80,8 +80,23 @@ class MemorizeMemories(Extension):
             else:
                 log_item.update(heading="Invalid memories format received.")
                 return
+        # Remove placeholder or empty memories that shouldn't be saved
+        PLACEHOLDER_TEXTS = {
+            "",
+            "none",
+            "no",
+            "n/a",
+            "no memory",
+            "no memories",
+            "no relevant information",
+            "no relevant info",
+            "no useful information",
+            "no useful info",
+            "nothing to remember",
+        }
+        memories = [m for m in memories if str(m).strip().lower() not in PLACEHOLDER_TEXTS]
 
-        if not isinstance(memories, list) or len(memories) == 0:
+        if not memories:
             log_item.update(heading="No useful information to memorize.")
             return
         else:


### PR DESCRIPTION
## Summary
- Filter out placeholder or empty memory fragments before saving
- Return early when no valid memory fragments remain

## Testing
- `pytest` *(fails: litellm.exceptions.AuthenticationError: OpenAIException - The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68c37fc8df9c8328b8f3f504d908b51d