### PR TITLE
Add docker publish tool

### DIFF
--- a/prompts/agent.system.tool.docker_publish.md
+++ b/prompts/agent.system.tool.docker_publish.md
@@ -1,8 +1,14 @@
 ### docker_publish
 
 build and optionally push docker images to github container registry
-default registry `ghcr.io`, username `bkhieb`, project `trailherotv`
+default registry `ghcr.io`, username sourced from `REGISTRY_USER`, project `trailherotv`
 default tag format `{date}-{iteration}` e.g. `20250913-1`
+
+required environment:
+- `REGISTRY_USER`: github packages / ghcr username used for repository namespace and docker login
+- `REGISTRY_PASSWORD`: personal access token (with `write:packages`) stored as a secret/environment variable used for login
+
+the tool aborts when `push=true` and either variable is missing, and surfaces a warning when building without credentials
 
 required args:
 - `image`: service or component name appended after project path
@@ -11,7 +17,7 @@ optional args:
 - `context_path`: build context directory, default `.`
 - `dockerfile`: path to Dockerfile relative to context
 - `project`: override project segment in image path
-- `username`: override registry username
+- `username`: override registry username when building without pushing (defaults to `REGISTRY_USER`)
 - `registry`: override container registry domain
 - `tag`: explicit tag override (use when not following date-iteration format)
 - `date`: date used when building default tag (`YYYYMMDD`)
@@ -23,13 +29,11 @@ optional args:
 - `target`: optional build stage target
 - `platforms`: list or comma separated platforms for `--platform`
 - `push`: boolean, set false to skip `docker push`
-- `registry_username`: username used for registry login (defaults to `username`)
-- `registry_password`: personal access token or password piped to `docker login`
 
 returns build and push logs together with the published image references
 
-before invoking confirm docker cli is installed, the build context contains the intended Dockerfile, and credentials for ghcr are configured or provided
-avoid exposing secrets in conversation history; supply `registry_password` only when necessary
+before invoking confirm docker cli is installed, the build context contains the intended Dockerfile, and the `REGISTRY_USER`/`REGISTRY_PASSWORD` variables are exported in the environment (e.g. via `export` or a secrets manager)
+avoid exposing secrets in conversation history; keep `REGISTRY_PASSWORD` sourced from a secret manager when possible
 
 usage example:
 


### PR DESCRIPTION
## Summary
- add a `docker_publish` tool that builds Docker images and optionally pushes them to GHCR using the date-iteration tag format
- provide prompt documentation covering required arguments, optional overrides, and usage examples for the new tool

## Testing
- PYTHONPATH=. pytest *(fails: missing `OPENAI_API_KEY` for rate limiter test)*

------
https://chatgpt.com/codex/tasks/task_e_68d04a0d0d788328ab0f68b3b92f03f7